### PR TITLE
Tests && Shell Scripts

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,3 @@
-clang++ server-async-test.cpp -o tests/async.test;
 cd build;
 cmake -G Ninja -DBUILD_SERVER=ON -DBUILD_CLIENT=ON .. && ninja;
 cd ..;

--- a/run_test.sh
+++ b/run_test.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+for file in tests/bin/*.test; do
+    if [[ -f "$file" ]]; then
+        echo "Running test: $file"
+        ./$file
+    fi
+done
+
+echo "Test execution complete."

--- a/tests.sh
+++ b/tests.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+EXCLUDED_TESTS=("server_async");
+
+for file in tests/*.cpp; do
+    if [[ -f "$file" ]]; then
+        name=$(basename "$file" .cpp)
+
+        if [[ " ${EXCLUDED_TESTS[@]} " =~ " ${name} " ]]; then
+            echo "Skipping test: $name"
+            continue
+        fi
+
+        test_file="tests/bin/${name}.test"
+        echo "Generating test file: $test_file"
+
+        clang++ -o $test_file $file -lgtest -lgtest_main -pthread;
+
+        chmod +x "$test_file"
+    fi
+done
+
+echo "Test generation complete."

--- a/tests/server_async.cpp
+++ b/tests/server_async.cpp
@@ -1,0 +1,61 @@
+#include <arpa/inet.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <cstdio>
+#include <string>
+
+std::string generate_random_message(size_t length) {
+    const char charset[] =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+    const size_t charset_size = sizeof(charset) - 1;
+    std::string result;
+    result.reserve(length);
+
+    for (size_t i = 0; i < length; ++i) {
+        result += charset[rand() % charset_size];
+    }
+    return result;
+}
+
+//There is no server response for this test.
+//It's only used to check server throughput
+int main(int argc, char* argv[]) {
+    int socket_fd = socket(AF_INET, SOCK_DGRAM, 0);
+    if (socket_fd < 0) {
+        perror("Socket creation failed");
+        return 1;
+    }
+
+    struct sockaddr_in addr;
+    // int m_port = 8080;
+    addr.sin_family = AF_INET;
+    // m_addr.sin_port = htons(m_port);
+    addr.sin_addr.s_addr = INADDR_ANY;
+
+    if (bind(socket_fd, (struct sockaddr*)&addr, sizeof(addr)) < 0) {
+        perror("Binding failed");
+        close(socket_fd);
+        return 1;
+    }
+
+    struct sockaddr_in dest_addr;
+    dest_addr.sin_family = AF_INET;
+    dest_addr.sin_port = htons(8080);
+    dest_addr.sin_addr.s_addr = inet_addr("0.0.0.0");
+
+    for (int i = 0; i < std::stoi(argv[1]); i++) {
+        std::string random_message = generate_random_message(1500);
+        ssize_t bytes_sent =
+            sendto(socket_fd, random_message.c_str(), 1500, 0, (struct sockaddr*)&dest_addr,
+                   sizeof(dest_addr));
+        if (bytes_sent < 0) {
+            perror("Send failed");
+            close(socket_fd);
+            return 1;
+        }
+    }
+
+    close(socket_fd);
+    return 0;
+}

--- a/tests/stateless_reset.cpp
+++ b/tests/stateless_reset.cpp
@@ -1,0 +1,52 @@
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <random>
+
+#include "../zclp++.hpp"
+#include "../zclp_utils/zclp_utils.hpp"
+
+namespace {
+std::mt19937_64 rng{std::random_device{}()};
+uint64_t getRandomValidValue() {
+    static const uint64_t MAX_VALID_VALUE = 0x3FFFFFFFFFFFFFFF;
+    std::uniform_int_distribution<uint64_t> dist(0, MAX_VALID_VALUE);
+    return dist(rng);
+}
+int getRandomBit() {
+    std::uniform_int_distribution<int> dist(0, 1);
+    return dist(rng);
+}
+}  // namespace
+
+TEST(StatelessResetTest, EncodeDecode) {
+    using namespace Packets;
+    for (int i = 0; i < 1000000; i++) {
+        StatelessReset st;
+        zclp_test_heplers::fill_stateless_reset(st);
+        st.unpredictable_bits = getRandomValidValue();
+        st.header_form = getRandomBit();
+        st.fixed_bit = getRandomBit();
+        uint8_t* encoded_buffer = nullptr;
+        auto enc_res =
+            zclp_encoding::encode_stateless_reset(st, encoded_buffer);
+        ASSERT_TRUE(enc_res.success);
+        ASSERT_GT(enc_res.len, 0u);
+        StatelessReset st_decoded;
+        auto dec_res = zclp_encoding::decode_stateless_reset(
+            encoded_buffer, enc_res.len, st_decoded);
+        ASSERT_TRUE(dec_res.success);
+        ASSERT_EQ(st.header_form, st_decoded.header_form);
+        ASSERT_EQ(st.fixed_bit, st_decoded.fixed_bit);
+        ASSERT_EQ(st.unpredictable_bits(), st_decoded.unpredictable_bits());
+        for (size_t j = 0; j < sizeof(st.reset_token); ++j) {
+            ASSERT_EQ(st.reset_token[j], st_decoded.reset_token[j]);
+        }
+        delete[] encoded_buffer;
+    }
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/tests/vl_integer.cpp
+++ b/tests/vl_integer.cpp
@@ -1,0 +1,68 @@
+#include <gtest/gtest.h>
+
+#include <cstdio>
+#include <random>
+
+#include "../zclp++.hpp"
+#include "../zclp_utils/zclp_utils.hpp"
+
+class VariableLengthIntegerTest : public ::testing::Test {
+  protected:
+    std::mt19937_64 rng{std::random_device{}()};
+
+    uint64_t getRandomValidValue() {
+        static const uint64_t MAX_VALID_VALUE = 0x3FFFFFFFFFFFFFFF;
+        std::uniform_int_distribution<uint64_t> dist(0, MAX_VALID_VALUE);
+        return dist(rng);
+    }
+};
+
+TEST_F(VariableLengthIntegerTest, EncodeDecodeCorrectness) {
+    for (int i = 0; i < 1000000; i++) {
+        uint64_t originalValue = getRandomValidValue();
+
+        VariableLengthInteger vl(originalValue);
+        uint8_t* encodedData;
+        auto encodingResult = zclp_encoding::encode_vl_integer(vl, encodedData);
+
+        VariableLengthInteger decodedVl;
+        auto decodingResult =
+            zclp_encoding::decode_vl_integer(encodedData, decodedVl);
+
+        ASSERT_EQ(decodedVl(), vl()) << "Value mismatch at iteration " << i;
+        ASSERT_EQ(decodedVl.size(), vl.size())
+            << "Length mismatch at iteration " << i;
+
+        delete[] encodedData;
+    }
+}
+
+TEST_F(VariableLengthIntegerTest, EdgeCaseValues) {
+    std::vector<uint64_t> edge_cases = {
+        0, 63, 64, 16383, 16384, 1073741823, 1073741824, 4611686018427387903};
+
+    // 2743802114606235814
+    // 4611686018427387903
+
+    for (size_t i = 0; i < edge_cases.size(); i++) {
+        uint64_t originalValue = edge_cases[i];
+
+        VariableLengthInteger vl(originalValue);
+        uint8_t* encodedData;
+        auto encodingResult = zclp_encoding::encode_vl_integer(vl, encodedData);
+
+        VariableLengthInteger decodedVl;
+        auto decodingResult =
+            zclp_encoding::decode_vl_integer(encodedData, decodedVl);
+        ASSERT_EQ(decodedVl(), vl()) << "Edge case failed for value: " << vl();
+        ASSERT_EQ(decodedVl.size(), vl.size())
+            << "Edge case length mismatch for value: " << vl.size();
+
+        delete[] encodedData;
+    }
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Removed server-async test from build script
. Test generating script. Script for running tests. Moved server_async test inside test dir. Note: that script is excluded from test generation!.
 Test for stateless reset packets encoding decoding, using gtest. Test for variable length integer encoding decoding, using gtest