### PR TITLE
zclp++ && zclp_utils update

### DIFF
--- a/client/client.cpp
+++ b/client/client.cpp
@@ -11,18 +11,18 @@
 #include "../tokio-cpp/tokio.hpp"
 
 Client::Client(uint16_t port) noexcept : m_port(port), m_max_mtu(1500) {
-    auto result_pb = tls.pub_key_to_bytes();
-    auto result_pr = tls.private_key_to_bytes();
+    // auto result_pb = tls.pub_key_to_bytes();
+    // auto result_pr = tls.private_key_to_bytes();
 
-    tls.strip_pem_formatting(result_pb->result, result_pb->len);
-    tls.strip_pem_formatting(result_pr->result, result_pr->len);
-    printf("%.*s\n", (int)result_pb->len, result_pb->result);
-    printf("%.*s\n", (int)result_pr->len, result_pr->result);
+    // tls.strip_pem_formatting(result_pb->result, result_pb->len);
+    // tls.strip_pem_formatting(result_pr->result, result_pr->len);
+    // printf("%.*s\n", (int)result_pb->len, result_pb->result);
+    // printf("%.*s\n", (int)result_pr->len, result_pr->result);
 
-    delete result_pb;
-    delete result_pr;
-    result_pb = nullptr;
-    result_pr = nullptr;
+    // delete result_pb;
+    // delete result_pr;
+    // result_pb = nullptr;
+    // result_pr = nullptr;
 }
 
 bool Client::run() {
@@ -110,7 +110,6 @@ bool Client::connect() {
     packet.length = 532;
     packet.token_length = 0;
     packet.token = nullptr;
-    packet.payload = Frames::Crypto();
 
     return true;
 }

--- a/client/main.cpp
+++ b/client/main.cpp
@@ -3,6 +3,7 @@
 #include <cstdio>
 #include <cstring>
 #include <thread>
+
 #include "client.h"
 
 int main(int argc, char* argv[]) {

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -8,7 +8,7 @@ ADD_EXECUTABLE(server
 
 set_target_properties(server PROPERTIES LINKER_LANGUAGE CXX)
 
-target_link_libraries(client
+target_link_libraries(server
     zclp_utils
 )
 


### PR DESCRIPTION
- **zclp++ update. Changed VariableLengthInteger value && len fields to private. Added size_t byte_size() for StatelessReset && VersionNegotiation, for calculating precise amount of bytes needed for encoding.**
- **zclp_utils update. Added 4 new methods: [printu8(), shift_left, shift_right, get_v1_len], and wrote implementation for few already existing methods including  vl_integer decode|encode, stateless_reset decode|encode.**
- **Successfully tested RSA key pair loading && formatting from files.**
- **Moved all test cases for Packets into google tests [inside test dir]**
- **Added missing zclp_utils lib to server's Cmake Lists**
