### PR TITLE
-U Tests

### DIFF
--- a/tests/header_protection.cpp
+++ b/tests/header_protection.cpp
@@ -1,0 +1,136 @@
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <random>
+#include <vector>
+
+#include "../zclp++.hpp"
+#include "../zclp_utils/zclp_utils.hpp"
+
+namespace {
+std::mt19937_64 rng{std::random_device{}()};
+
+uint32_t getRandomConnectionID() {
+    std::uniform_int_distribution<uint32_t> dist(0, 0xFFFFFFFF);
+    return dist(rng);
+}
+
+uint8_t getRandomPacketNumberLength() {
+    std::uniform_int_distribution<uint8_t> dist(0, 3);
+    return dist(rng);
+}
+
+uint32_t getRandomPacketNumber() {
+    std::uniform_int_distribution<uint32_t> dist(0, 0xFFFFFFF);
+    return dist(rng);
+}
+
+}  // namespace
+
+TEST(ShortHeaderTest, ProtectionApplyRemove) {
+    using namespace Packets;
+
+    for (int i = 0; i < 1000000; i++) {
+        Packets::ShortHeader sh;
+        sh.header_form = 0;
+        sh.fixed_bit = 1;
+        sh.spin_bit = 0;
+        sh.reserved_bits = 0;
+        sh.key_phase = 1;
+        sh.packet_number_length = getRandomPacketNumberLength();
+        sh.destination_connection = getRandomConnectionID();
+        sh.packet_number = getRandomPacketNumber();
+
+        std::vector<uint8_t> sample = {0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe,
+                                       0xba, 0xbe, 0x00, 0x11, 0x22, 0x33,
+                                       0x44, 0x55, 0x66, 0x77};
+
+        std::array<uint8_t, 16> hp_key = {0x1f, 0x2b, 0x3c, 0x4d, 0x5e, 0x6f,
+                                          0x70, 0x81, 0x92, 0xa3, 0xb4, 0xc5,
+                                          0xd6, 0xe7, 0xf8, 0x09};
+
+        Packets::ShortHeader sh_original = sh;
+
+        std::vector<uint8_t> short_header_protected(
+            sizeof(Packets::ShortHeader));
+        std::memcpy(short_header_protected.data(), &sh,
+                    sizeof(Packets::ShortHeader));
+        bool res_a = zclp_tls::apply_header_protection(short_header_protected,
+                                                       sample, hp_key);
+        ASSERT_EQ(res_a, true);
+        std::vector<uint8_t> short_header_restored = short_header_protected;
+        bool res_r = zclp_tls::remove_header_protection(short_header_restored,
+                                                        sample, hp_key);
+        ASSERT_EQ(res_r, true);
+        Packets::ShortHeader sh_restored;
+        std::memcpy(&sh_restored, short_header_restored.data(),
+                    sizeof(Packets::ShortHeader));
+
+        ASSERT_EQ(sh_original.header_form, sh_restored.header_form);
+        ASSERT_EQ(sh_original.fixed_bit, sh_restored.fixed_bit);
+        ASSERT_EQ(sh_original.spin_bit, sh_restored.spin_bit);
+        ASSERT_EQ(sh_original.reserved_bits, sh_restored.reserved_bits);
+        ASSERT_EQ(sh_original.key_phase, sh_restored.key_phase);
+        ASSERT_EQ(sh_original.packet_number_length,
+                  sh_restored.packet_number_length);
+        ASSERT_EQ(sh_original.destination_connection,
+                  sh_restored.destination_connection);
+        ASSERT_EQ(sh_original.packet_number, sh_restored.packet_number);
+    }
+}
+
+TEST(LongHeaderTest, ProtectionApplyRemove) {
+    using namespace Packets;
+
+    for (int i = 0; i < 1000000; i++) {
+        Packets::LongHeader lh;
+        lh.header_form = 1;
+        lh.fixed_bit = 1;
+        lh.packet_type = getRandomPacketNumber();
+        lh.reserved_bits = 0;
+        lh.packet_number_length = getRandomPacketNumberLength();
+        lh.version_id = getRandomPacketNumber();
+        lh.destination_connection_id = getRandomConnectionID();
+        lh.source_connection_id = getRandomConnectionID();
+
+        std::vector<uint8_t> sample = {0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe,
+                                       0xba, 0xbe, 0x00, 0x11, 0x22, 0x33,
+                                       0x44, 0x55, 0x66, 0x77};
+
+        std::array<uint8_t, 16> hp_key = {0x1f, 0x2b, 0x3c, 0x4d, 0x5e, 0x6f,
+                                          0x70, 0x81, 0x92, 0xa3, 0xb4, 0xc5,
+                                          0xd6, 0xe7, 0xf8, 0x09};
+
+        Packets::LongHeader lh_original = lh;
+        std::vector<uint8_t> long_header_protected(sizeof(Packets::LongHeader));
+        std::memcpy(long_header_protected.data(), &lh,
+                    sizeof(Packets::LongHeader));
+        bool res_a = zclp_tls::apply_header_protection(long_header_protected,
+                                                       sample, hp_key);
+        ASSERT_EQ(res_a, true);
+        std::vector<uint8_t> long_header_restored = long_header_protected;
+        bool res_r = zclp_tls::remove_header_protection(long_header_restored,
+                                                        sample, hp_key);
+        ASSERT_EQ(res_r, true);
+        Packets::LongHeader lh_restored;
+        std::memcpy(&lh_restored, long_header_restored.data(),
+                    sizeof(Packets::LongHeader));
+
+        ASSERT_EQ(lh_original.header_form, lh_restored.header_form);
+        ASSERT_EQ(lh_original.fixed_bit, lh_restored.fixed_bit);
+        ASSERT_EQ(lh_original.packet_type, lh_restored.packet_type);
+        ASSERT_EQ(lh_original.reserved_bits, lh_restored.reserved_bits);
+        ASSERT_EQ(lh_original.packet_number_length,
+                  lh_restored.packet_number_length);
+        ASSERT_EQ(lh_original.version_id, lh_restored.version_id);
+        ASSERT_EQ(lh_original.destination_connection_id,
+                  lh_restored.destination_connection_id);
+        ASSERT_EQ(lh_original.source_connection_id,
+                  lh_restored.source_connection_id);
+    }
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/tests/long_header.cpp
+++ b/tests/long_header.cpp
@@ -44,7 +44,7 @@ TEST(LongHeaderTest, EncodeDecode) {
     using namespace Packets;
 
     for (int i = 0; i < 1000000; i++) {
-        LongHeader lh;
+        Packets::LongHeader lh;
         lh.header_form = getRandomBit();
         lh.fixed_bit = getRandomBit();
         lh.packet_type = getRandomPacketType();
@@ -59,7 +59,7 @@ TEST(LongHeaderTest, EncodeDecode) {
         ASSERT_TRUE(enc_res.success);
         ASSERT_GT(enc_res.len, 0u);
 
-        LongHeader lh_decoded;
+        Packets::LongHeader lh_decoded;
         auto dec_res = zclp_encoding::decode_long_header(
             encoded_buffer, enc_res.len, lh_decoded);
         ASSERT_TRUE(dec_res.success);

--- a/tests/protected_long_header.cpp
+++ b/tests/protected_long_header.cpp
@@ -39,7 +39,7 @@ TEST(ProtectedLongHeaderTest, EncodeDecode) {
     using namespace Packets;
 
     for (int i = 0; i < 1000000; i++) {
-        ProtectedLongHeader plh;
+        Packets::ProtectedLongHeader plh;
         plh.header_form = getRandomBit();
         plh.fixed_bit = getRandomBit();
         plh.packet_type = getRandomPacketType();
@@ -54,7 +54,7 @@ TEST(ProtectedLongHeaderTest, EncodeDecode) {
         ASSERT_TRUE(enc_res.success);
         ASSERT_GT(enc_res.len, 0u);
 
-        ProtectedLongHeader plh_decoded;
+        Packets::ProtectedLongHeader plh_decoded;
         auto dec_res = zclp_encoding::decode_protected_long_header(
             encoded_buffer, enc_res.len, plh_decoded);
         ASSERT_TRUE(dec_res.success);

--- a/tests/stateless_reset.cpp
+++ b/tests/stateless_reset.cpp
@@ -22,7 +22,7 @@ int getRandomBit() {
 TEST(StatelessResetTest, EncodeDecode) {
     using namespace Packets;
     for (int i = 0; i < 1000000; i++) {
-        StatelessReset st;
+        Packets::StatelessReset st;
         zclp_test_heplers::fill_stateless_reset(st);
         st.unpredictable_bits = getRandomValidValue();
         st.header_form = getRandomBit();
@@ -32,7 +32,7 @@ TEST(StatelessResetTest, EncodeDecode) {
             zclp_encoding::encode_stateless_reset(st, encoded_buffer);
         ASSERT_TRUE(enc_res.success);
         ASSERT_GT(enc_res.len, 0u);
-        StatelessReset st_decoded;
+        Packets::StatelessReset st_decoded;
         auto dec_res = zclp_encoding::decode_stateless_reset(
             encoded_buffer, enc_res.len, st_decoded);
         ASSERT_TRUE(dec_res.success);

--- a/tests/version_negotiation.cpp
+++ b/tests/version_negotiation.cpp
@@ -37,7 +37,7 @@ TEST(VersionNegotiationTest, EncodeDecode) {
     using namespace Packets;
 
     for (int i = 0; i < 1000000; i++) {
-        VersionNegotiation vn;
+        Packets::VersionNegotiation vn;
         vn.header_form = getRandomBit();
         vn.unused = getRandomBit() & 0x3F;  // Ensure it's a 6-bit value
         vn.version_id = getRandomVersionID();
@@ -51,7 +51,7 @@ TEST(VersionNegotiationTest, EncodeDecode) {
         ASSERT_TRUE(enc_res.success);
         ASSERT_GT(enc_res.len, 0u);
 
-        VersionNegotiation vn_decoded;
+        Packets::VersionNegotiation vn_decoded;
         auto dec_res = zclp_encoding::decode_version_negotiation(
             encoded_buffer, enc_res.len, vn_decoded);
         ASSERT_TRUE(dec_res.success);


### PR DESCRIPTION
Updated tests. Explicit use of Packets:: namespace for long_header, protected_header, stateless_reset and version_negotiation. Added new test for header protection, for both short and long headers.